### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -1,5 +1,8 @@
 name: Swift Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/emqx/swift-mqtt/security/code-scanning/3](https://github.com/emqx/swift-mqtt/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out the repository and runs Swift build and test commands, it likely only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`test`) in this workflow.

Steps to implement the fix:
1. Add a `permissions` block at the top level of the workflow file.
2. Set the permissions to `contents: read`, which is sufficient for the workflow's operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
